### PR TITLE
Add product_type column back to categorical columns

### DIFF
--- a/datasets/ETL/MortgageETL.ipynb
+++ b/datasets/ETL/MortgageETL.ipynb
@@ -264,6 +264,7 @@
     "        \"property_type\",\n",
     "        \"occupancy_status\",\n",
     "        \"property_state\",\n",
+    "        \"product_type\",\n",
     "        \"relocation_mortgage_indicator\",\n",
     "        \"seller_name\",\n",
     "        \"mod_flag\"\n",


### PR DESCRIPTION
- This will resolve the error that XGBoost complains no 'product_type' column in the dateset